### PR TITLE
Fix broken links

### DIFF
--- a/hassio_install.sh
+++ b/hassio_install.sh
@@ -5,10 +5,10 @@ ARCH=$(uname -m)
 DOCKER_REPO=homeassistant
 DATA_SHARE=/usr/share/hassio
 URL_VERSION="https://s3.amazonaws.com/hassio-version/stable.json"
-URL_BIN_HASSIO="https://raw.githubusercontent.com/home-assistant/hassio-installer/master/install/files/hassio-supervisor"
-URL_BIN_APPARMOR="https://raw.githubusercontent.com/home-assistant/hassio-installer/master/install/files/hassio-apparmor"
-URL_SERVICE_HASSIO="https://raw.githubusercontent.com/home-assistant/hassio-installer/master/install/files/hassio-supervisor.service"
-URL_SERVICE_APPARMOR="https://raw.githubusercontent.com/home-assistant/hassio-installer/master/install/files/hassio-apparmor.service"
+URL_BIN_HASSIO="https://raw.githubusercontent.com/home-assistant/hassio-installer/master/files/hassio-supervisor"
+URL_BIN_APPARMOR="https://raw.githubusercontent.com/home-assistant/hassio-installer/master/files/hassio-apparmor"
+URL_SERVICE_HASSIO="https://raw.githubusercontent.com/home-assistant/hassio-installer/master/files/hassio-supervisor.service"
+URL_SERVICE_APPARMOR="https://raw.githubusercontent.com/home-assistant/hassio-installer/master/files/hassio-apparmor.service"
 URL_APPARMOR_PROFILE="http://s3.amazonaws.com/hassio-version/apparmor.txt"
 
 # Check env


### PR DESCRIPTION
Fixes broken links in installations script.
These links result in the files downloaded with `404: Not Found` as the content.