### PR TITLE
Warn the user about NOT deleting containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,24 @@ curl -sL https://raw.githubusercontent.com/home-assistant/hassio-installer/maste
 - raspberrypi3
 - raspberrypi3-64
 - tinker
+
+## !!!WARNING!!! DO NOT DELETE CREATED CONTAINERS
+This installer will create the base `homeassistant` container for you, but if you delete if (`docker rm` or `docker prune`) the supervisor will not be able to re-create it for you.
+If you wish to still safelly use `docker containers prune` you might want to add the `--filter` flag to your command.
+Example:
+```sh
+$ docker container prune --filter label!=homeassistant
+```
+or, for a greater peace of mind, you can add the following config to your `~/.docker/config.json`:
+```javascript
+{
+  "pruneFilters": ["label!=homeassistant", "label!=hassio_supervisor", "label!=addon*"]
+}
+```
+
+### Ouch, I deleted it, and now what?
+If you accidentally deleted the `homeassistant` container, and now it's not coming back, you will need to run this installer again. If that didn't work, you will need to manually reset your docker environment and run the installer again:
+- stop docker deamon
+- rm -fr /var/lib/docker/*
+- start docker deamon
+- run installer again

--- a/README.md
+++ b/README.md
@@ -59,8 +59,11 @@ curl -sL https://raw.githubusercontent.com/home-assistant/hassio-installer/maste
 - tinker
 
 ## !!!WARNING!!! DO NOT DELETE CREATED CONTAINERS
-This installer will create the base `homeassistant` container for you, but if you delete if (`docker rm` or `docker prune`) the supervisor will not be able to re-create it for you.
+
+This installer will create the base `homeassistant` container for you, but if you delete if (`docker rm` or `docker prune`) the supervisor will not be able to re-create it for you. Hass.io is a Eco System and Container Orchastrator they don't support manual adjustments.
+
 If you wish to still safelly use `docker containers prune` you might want to add the `--filter` flag to your command.
+
 Example:
 ```sh
 $ docker container prune --filter label!=homeassistant
@@ -71,10 +74,3 @@ or, for a greater peace of mind, you can add the following config to your `~/.do
   "pruneFilters": ["label!=homeassistant", "label!=hassio_supervisor", "label!=addon*"]
 }
 ```
-
-### Ouch, I deleted it, and now what?
-If you accidentally deleted the `homeassistant` container, and now it's not coming back, you will need to run this installer again. If that didn't work, you will need to manually reset your docker environment and run the installer again:
-- stop docker deamon
-- rm -fr /var/lib/docker/*
-- start docker deamon
-- run installer again


### PR DESCRIPTION
As the `supervisor` does not support creating the homeassistant container if accidentally deleted, let's warn the users before it's too late and perhaps give a bare minimum of possible ways to recover.

I  personally ran into this issue twice, knowing it up front would have saved me quite a bit of time banging my head on the shell and the web.