### PR TITLE
Support custom prefix (/usr) and sysconfdir (/etc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ curl -sL https://raw.githubusercontent.com/home-assistant/hassio-installer/maste
 
 ### Command line arguments
 | argument           | default                                                                                                                                                                             | description                                            |
-|--------------------|-------------------|--------------------------------------------------------|
-| -m \| --machine    |                   | On a special platform they need set a machine type use |
-| -d \| --data-share | /usr/share/hassio | data folder for hass.io installation                   |
+|--------------------|----------------------|--------------------------------------------------------|
+| -m \| --machine    |                      | On a special platform they need set a machine type use |
+| -d \| --data-share | $PREFIX/share/hassio | data folder for hass.io installation                   |
+| -p \| --prefix     | /usr                 | Binary prefix for hass.io installation                 |
+| -s \| --sysconfdir | /etc                 | Configuration directory for hass.io installation       |
 
 you can set these parameters by appending ` -- <parameter> <value>` like:
 

--- a/files/hassio-apparmor
+++ b/files/hassio-apparmor
@@ -2,7 +2,7 @@
 set -e
 
 # Load configs
-CONFIG_FILE=/etc/hassio.json
+CONFIG_FILE=%%HASSIO_CONFIG%%
 
 # Read configs
 DATA="$(jq --raw-output '.data // "/usr/share/hassio"' ${CONFIG_FILE})"

--- a/files/hassio-apparmor.service
+++ b/files/hassio-apparmor.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Hass.io AppArmor
 Wants=hassio-supervisor.service
-Before=docker.service hassio-supervisor.service
+Before=%%DOCKER_SERVICE%% hassio-supervisor.service
 
 [Service]
 Type=oneshot

--- a/files/hassio-apparmor.service
+++ b/files/hassio-apparmor.service
@@ -6,7 +6,7 @@ Before=%%DOCKER_SERVICE%% hassio-supervisor.service
 [Service]
 Type=oneshot
 RemainAfterExit=true
-ExecStart=/usr/sbin/hassio-apparmor
+ExecStart=%%HASSIO_APPARMOR_BINARY%%
 
 [Install]
 WantedBy=multi-user.target

--- a/files/hassio-supervisor
+++ b/files/hassio-supervisor
@@ -2,7 +2,7 @@
 set -e
 
 # Load configs
-CONFIG_FILE=/etc/hassio.json
+CONFIG_FILE=%%HASSIO_CONFIG%%
 
 SUPERVISOR="$(jq --raw-output '.supervisor' ${CONFIG_FILE})"
 HOMEASSISTANT="$(jq --raw-output '.homeassistant' ${CONFIG_FILE})"

--- a/files/hassio-supervisor.service
+++ b/files/hassio-supervisor.service
@@ -1,15 +1,15 @@
 [Unit]
 Description=Hass.io supervisor
-Requires=docker.service
-After=docker.service dbus.socket
+Requires=%%DOCKER_SERVICE%%
+After=%%DOCKER_SERVICE%% dbus.socket
 
 [Service]
 Type=simple
 Restart=always
 RestartSec=5s
-ExecStartPre=-/usr/bin/docker stop hassio_supervisor
+ExecStartPre=-%%DOCKER_BINARY%% stop hassio_supervisor
 ExecStart=/usr/sbin/hassio-supervisor
-ExecStop=-/usr/bin/docker stop hassio_supervisor
+ExecStop=-%%DOCKER_BINARY%% stop hassio_supervisor
 
 [Install]
 WantedBy=multi-user.target

--- a/files/hassio-supervisor.service
+++ b/files/hassio-supervisor.service
@@ -8,7 +8,8 @@ Type=simple
 Restart=always
 RestartSec=5s
 ExecStartPre=-%%DOCKER_BINARY%% stop hassio_supervisor
-ExecStart=/usr/sbin/hassio-supervisor
+ExecStartPre=-%%DOCKER_BINARY%% stop hassio_supervisor
+ExecStart=%%HASSIO_BINARY%%
 ExecStop=-%%DOCKER_BINARY%% stop hassio_supervisor
 
 [Install]

--- a/hassio_install.sh
+++ b/hassio_install.sh
@@ -2,7 +2,7 @@
 set -e
 
 ARCH=$(uname -m)
-PREFIX=""
+DOCKER_DAEMON_CONFIG=/etc/docker/daemon.json
 SNAP=false
 DOCKER_REPO=homeassistant
 DOCKER_SERVICE=docker.service
@@ -28,7 +28,7 @@ command -v nmcli > /dev/null 2>&1 || echo "[Warning] No NetworkManager support o
 #detect if running on snapped docker
 if snap list docker >/dev/null 2>&1; then
     SNAP=true
-    PREFIX=/root/snap/docker/current
+    DOCKER_DAEMON_CONFIG=/root/snap/docker/current/etc/docker/daemon.json
     DATA_SHARE=/root/snap/docker/common/hassio
     CONFIG=$DATA_SHARE/hassio.json
     DOCKER_SERVICE="snap.docker.dockerd.service"
@@ -127,10 +127,10 @@ EOF
 ##
 # Check DNS settings
 DOCKER_VERSION="$(docker --version | grep -Po "\d{2}\.\d{2}\.\d")"
-if version_gt "18.09.0" "${DOCKER_VERSION}" && [ ! -e "$PREFIX/etc/docker/daemon.json" ]; then
+if version_gt "18.09.0" "${DOCKER_VERSION}" && [ ! -e "$DOCKER_DAEMON_CONFIG" ]; then
     echo "[Warning] Create DNS settings for Docker to avoid systemd bug!"
-    mkdir -p $PREFIX/etc/docker
-    echo '{"dns": ["8.8.8.8", "8.8.4.4"]}' > $PREFIX/etc/docker/daemon.json
+    mkdir -p $(dirname ${DOCKER_DAEMON_CONFIG})
+    echo '{"dns": ["8.8.8.8", "8.8.4.4"]}' > $DOCKER_DAEMON_CONFIG
 
     echo "[Info] Restart Docker and wait 30 seconds"
     systemctl restart $DOCKER_SERVICE && sleep 30

--- a/hassio_install.sh
+++ b/hassio_install.sh
@@ -6,8 +6,6 @@ DOCKER_DAEMON_CONFIG=/etc/docker/daemon.json
 DOCKER_BINARY=/usr/bin/docker
 DOCKER_REPO=homeassistant
 DOCKER_SERVICE=docker.service
-DATA_SHARE=/usr/share/hassio
-CONFIG=/etc/hassio.json
 URL_VERSION="https://version.home-assistant.io/stable.json"
 URL_BIN_HASSIO="https://raw.githubusercontent.com/home-assistant/hassio-installer/master/files/hassio-supervisor"
 URL_BIN_APPARMOR="https://raw.githubusercontent.com/home-assistant/hassio-installer/master/files/hassio-apparmor"
@@ -49,6 +47,14 @@ while [[ $# -gt 0 ]]; do
             DATA_SHARE=$2
             shift
             ;;
+        -p|--prefix)
+            PREFIX=$2
+            shift
+            ;;
+        -s|--sysconfdir)
+            SYSCONFDIR=$2
+            shift
+            ;;
         *)
             echo "[Error] Unrecognized option $1"
             exit 1
@@ -56,6 +62,11 @@ while [[ $# -gt 0 ]]; do
     esac
     shift
 done
+
+PREFIX=${PREFIX:-/usr}
+SYSCONFDIR=${SYSCONFDIR:-/etc}
+DATA_SHARE=${DATA_SHARE:-$PREFIX/share/hassio}
+CONFIG=$SYSCONFDIR/hassio.json
 
 # Generate hardware options
 case $ARCH in
@@ -115,7 +126,7 @@ HASSIO_VERSION=$(curl -s $URL_VERSION | jq -e -r '.supervisor')
 
 ##
 # Write config
-cat > $CONFIG <<- EOF
+cat > "$CONFIG" <<- EOF
 {
     "supervisor": "${HASSIO_DOCKER}",
     "homeassistant": "${HOMEASSISTANT_DOCKER}",
@@ -128,7 +139,7 @@ EOF
 DOCKER_VERSION="$(docker --version | grep -Po "\d{2}\.\d{2}\.\d")"
 if version_gt "18.09.0" "${DOCKER_VERSION}" && [ ! -e "$DOCKER_DAEMON_CONFIG" ]; then
     echo "[Warning] Create DNS settings for Docker to avoid systemd bug!"
-    mkdir -p $(dirname ${DOCKER_DAEMON_CONFIG})
+    mkdir -p "$(dirname ${DOCKER_DAEMON_CONFIG})"
     echo '{"dns": ["8.8.8.8", "8.8.4.4"]}' > $DOCKER_DAEMON_CONFIG
 
     echo "[Info] Restart Docker and wait 30 seconds"
@@ -144,13 +155,16 @@ docker tag "$HASSIO_DOCKER:$HASSIO_VERSION" "$HASSIO_DOCKER:latest" > /dev/null
 ##
 # Install Hass.io Supervisor
 echo "[Info] Install supervisor startup scripts"
-curl -sL ${URL_BIN_HASSIO} > /usr/sbin/hassio-supervisor
-curl -sL ${URL_SERVICE_HASSIO} > /etc/systemd/system/hassio-supervisor.service
+curl -sL ${URL_BIN_HASSIO} > "${PREFIX}"/sbin/hassio-supervisor
+curl -sL ${URL_SERVICE_HASSIO} > "${SYSCONFDIR}"/systemd/system/hassio-supervisor.service
 
-sed -i "s,%%HASSIO_CONFIG%%,${CONFIG},g" /usr/sbin/hassio-supervisor
-sed -i "s,%%DOCKER_BINARY%%,${DOCKER_BINARY},g; s,%%DOCKER_SERVICE%%,${DOCKER_SERVICE},g" /etc/systemd/system/hassio-supervisor.service
+sed -i "s,%%HASSIO_CONFIG%%,${CONFIG},g" "${PREFIX}"/sbin/hassio-supervisor
+sed -i -e "s,%%DOCKER_BINARY%%,${DOCKER_BINARY},g" \
+       -e "s,%%DOCKER_SERVICE%%,${DOCKER_SERVICE},g" \
+       -e "s,%%HASSIO_BINARY%%,${PREFIX}/sbin/hassio-supervisor,g" \
+       "${SYSCONFDIR}"/systemd/system/hassio-supervisor.service
 
-chmod a+x /usr/sbin/hassio-supervisor
+chmod a+x "${PREFIX}"/sbin/hassio-supervisor
 systemctl enable hassio-supervisor.service
 
 #
@@ -158,14 +172,16 @@ systemctl enable hassio-supervisor.service
 if command -v apparmor_parser > /dev/null 2>&1; then
     echo "[Info] Install AppArmor scripts"
     mkdir -p "${DATA_SHARE}"/apparmor
-    curl -sL ${URL_BIN_APPARMOR} > /usr/sbin/hassio-apparmor
-    curl -sL ${URL_SERVICE_APPARMOR} > /etc/systemd/system/hassio-apparmor.service
+    curl -sL ${URL_BIN_APPARMOR} > "${PREFIX}"/sbin/hassio-apparmor
+    curl -sL ${URL_SERVICE_APPARMOR} > "${SYSCONFDIR}"/systemd/system/hassio-apparmor.service
     curl -sL ${URL_APPARMOR_PROFILE} > "${DATA_SHARE}"/apparmor/hassio-supervisor
 
-    sed -i "s,%%HASSIO_CONFIG%%,${CONFIG},g" /usr/sbin/hassio-apparmor
-    sed -i "s,%%DOCKER_SERVICE%%,${DOCKER_SERVICE},g" /etc/systemd/system/hassio-apparmor.service
+    sed -i "s,%%HASSIO_CONFIG%%,${CONFIG},g" "${PREFIX}"/sbin/hassio-apparmor
+    sed -i -e "s,%%DOCKER_SERVICE%%,${DOCKER_SERVICE},g" \
+	   -e "s,%%HASSIO_APPARMOR_BINARY%%,${PREFIX}/sbin/hassio-apparmor,g" \
+	   "${SYSCONFDIR}"/systemd/system/hassio-apparmor.service
 
-    chmod a+x /usr/sbin/hassio-apparmor
+    chmod a+x "${PREFIX}"/sbin/hassio-apparmor
     systemctl enable hassio-apparmor.service
     systemctl start hassio-apparmor.service
 fi


### PR DESCRIPTION
This refactors the path replacement a bit and uses @VARIABLE@ in the templates to make replacement easier to follow and safe in case of multiple similar paths. With that one can use a custom location for /usr or /etc, e.g.

```
curl -sL https://raw.githubusercontent.com/home-assistant/hassio-installer/master/hassio_install.sh | bash -s -- -p /usr/local -s /usr/local/etc/
```

Closes #25.