### PR TITLE
Fix shebang

### DIFF
--- a/hassio_install.sh
+++ b/hassio_install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 ARCH=$(uname -m)


### PR DESCRIPTION
# Summary

First of all, thank you for this installer!

This PR fixes the shebang which does not work on some flavor of *nix (See https://stackoverflow.com/questions/10376206/what-is-the-preferred-bash-shebang).

Otherwise, if `sh` is sufficient, `/bin/sh` is POSIX compliant (while `/bin/bash` is not).

Thank you