### PR TITLE
Limit Supervisor container to 100mb memory

### DIFF
--- a/files/hassio-supervisor
+++ b/files/hassio-supervisor
@@ -28,6 +28,7 @@ runSupervisor() {
         --privileged \
         $APPARMOR \
         --security-opt seccomp=unconfined \
+        --memory=100m \
         -v /var/run/docker.sock:/var/run/docker.sock \
         -v /var/run/dbus:/var/run/dbus \
         -v "${HASSIO_DATA}":/data \


### PR DESCRIPTION
Over time the supervisor container uses more and more RAM (up to ~3.5GB) until it is either restarted or updated to a new version. Then eventually it starts eating RAM again. This change limits the container to a hard cap of 100mb. I have been running this change on my own system (actually with a stricter limit of 50mb) since September 15 and have not noticed any ill effects or unexpected container restarts.

Also, it's just [best security practice to limit how much memory a container can consume](https://docs.docker.com/engine/security/security/) :)