### PR TITLE
Add warning when the ModemManager is enabled

### DIFF
--- a/hassio_install.sh
+++ b/hassio_install.sh
@@ -22,6 +22,11 @@ command -v dbus-daemon > /dev/null 2>&1 || { echo "[Error] Please install dbus f
 command -v nmcli > /dev/null 2>&1 || echo "[Warning] No NetworkManager support on host."
 command -v apparmor_parser > /dev/null 2>&1 || echo "[Warning] No AppArmor support on host."
 
+# Check if Modem Manager is enabled
+if systemctl list-unit-files ModemManager.service | grep enabled; then
+    echo "[Warning] ModemManager service is enabled. This might cause issue when using serial devices."
+fi
+
 # Detect if running on snapped docker
 if snap list docker >/dev/null 2>&1; then
     DOCKER_BINARY=/snap/bin/docker


### PR DESCRIPTION
Adds a warning to the Hass.io installer when it detects the ModemManager is still enabled as a service.

This might cause issues with serial devices (e.g., Z-Wave sticks).

The documentation (and my good old gist) have been adjusted to add the disabling of the ModemManager as part of the installation steps to take.

Output:

```txt
root@test-hassio-linux:~# curl -sL https://raw.githubusercontent.com/home-assistant/hassio-installer/frenck-2019-0277/hassio_install.sh | bash -s
ModemManager.service enabled
[Warning] ModemManager service is enabled. This might cause issue when using serial devices.
[Info] Install supervisor Docker container
```