### PR TITLE
Ensure dirs exist if using custom prefix, sysconfdir, or data-share

### DIFF
--- a/hassio_install.sh
+++ b/hassio_install.sh
@@ -123,8 +123,24 @@ fi
 ### Main
 
 # Init folders
+if [ ! -d "$PREFIX" ]; then
+    mkdir -p "$PREFIX"
+fi
+
+if [ ! -d "$SYSCONFDIR" ]; then
+    mkdir -p "$SYSCONFDIR"
+fi
+
 if [ ! -d "$DATA_SHARE" ]; then
     mkdir -p "$DATA_SHARE"
+fi
+
+if [ ! -d "${PREFIX}/sbin/" ]; then
+    mkdir -p "${PREFIX}/sbin/"
+fi
+
+if [ ! -d "${SYSCONFDIR}/systemd/system/" ]; then
+    mkdir -p "${SYSCONFDIR}/systemd/system/"
 fi
 
 # Read infos from web


### PR DESCRIPTION
This makes sure dirs exist if a user specifies a custom prefix, sysconfig, or data-share directory for users who want to completely isolate Hassio from the rest of their system by installing into a different location, like `/opt/hassio/`.

